### PR TITLE
fix(users-ms): use query.id when fetching user in GetUserQueryHandler

### DIFF
--- a/workspace/apps/users-ms/src/app/application/features/users/queries/get/get-user.query-handler.ts
+++ b/workspace/apps/users-ms/src/app/application/features/users/queries/get/get-user.query-handler.ts
@@ -9,18 +9,18 @@ import { isNilOrEmpty } from '@vanguard-nx/utils';
 import { UserNotFoundException } from '../../exceptions';
 
 @QueryHandlerStrict(GetUserQuery)
-export class GetUserQueryHandler implements IQueryHandler<GetUserQuery, User | null> {
+export class GetUserQueryHandler implements IQueryHandler<GetUserQuery, User> {
   constructor(@Inject(USER_REPO) protected readonly repo: IUserRepo, @InjectPinoLogger(GetUserQueryHandler.name) private logger: PinoLogger) {}
 
-  public async execute(query: GetUserQuery): Promise<User | null> {
+  public async execute(query: GetUserQuery): Promise<User> {
     this.logger.info(`Executing Query "${GetUserQuery.name}"`);
 
-    const user = await this.repo.getAsync('1');
+    const user = await this.repo.getAsync(query.id);
 
     if (isNilOrEmpty(user)) {
       throw new UserNotFoundException(`User with Id: ${query.id} not found.`);
     }
 
-    return user;
+    return user!;
   }
 }


### PR DESCRIPTION
- Changed GetUserQueryHandler to use query.id instead of hardcoded '1' for fetching user.
- Improved error handling for missing users.

## Description

This PR updates the `GetUserQueryHandler` to use the ID provided in the query (`query.id`) instead of a hardcoded value ('1') when fetching a user from the repository.

Fixes: 
Issue not reported.
---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe below):

---

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have tested my code and it works as expected
- [x] I have updated documentation if needed
- [x] I have linked the related issue if applicable

---

## Additional Information

N/A